### PR TITLE
Refactor is_palindrome with optional numeric validation

### DIFF
--- a/lib/Math/Palindrome.pm
+++ b/lib/Math/Palindrome.pm
@@ -123,8 +123,12 @@ sub _previous_even_digits {
 
 ##############################################################
 #Now, all export functions
-#confirm if the number is palindrome 
-sub is_palindrome {($_[0] == reverse $_[0]) ? return 1 : return 0}
+#confirm if the number is palindrome
+sub is_palindrome {
+        my ($x, $validate) = @_;
+        croak "Just work with natural numbers!\n" if $validate && $x !~ /^\d+$/;
+        return $x eq reverse $x;
+}
 #require the next palindrome 
 sub next_palindrome {
 	my $num = shift;

--- a/t/is_palindrome.t
+++ b/t/is_palindrome.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::Simple tests => 27;
+use Test::Simple tests => 30;
 use Math::Palindrome 'is_palindrome';
 
 
@@ -22,7 +22,7 @@ ok(is_palindrome(33));
 ok(is_palindrome(44));
 ok(is_palindrome(55));
 ok(is_palindrome(66));
-ok(!is_palindrome(77));
+ok(is_palindrome(77));
 ok(is_palindrome(88));
 ok(is_palindrome(99));
 ok(!is_palindrome(100));
@@ -31,5 +31,10 @@ ok(!is_palindrome(1000));
 ok(is_palindrome(1001));
 ok(!is_palindrome(10000));
 ok(is_palindrome(10001));
-ok(is_palindrome(100000));
+ok(!is_palindrome(100000));
 ok(is_palindrome(100001));
+
+ok(is_palindrome('abcba'));
+ok(!is_palindrome('abc'));
+eval { is_palindrome('foo', 1) };
+ok($@);


### PR DESCRIPTION
## Summary
- Refactor `is_palindrome` to use string comparison
- Add optional numeric validation that croaks on non-numeric input
- Fix and extend palindrome tests for new behavior

## Testing
- `prove -l t/is_palindrome.t`
- `prove -l t/*.t` *(fails: t/previous_palindrome.t syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_68bcafc419dc832a959093b47b777d4f