### PR TITLE
Validate numeric inputs for palindrome functions

### DIFF
--- a/lib/Math/Palindrome.pm
+++ b/lib/Math/Palindrome.pm
@@ -5,6 +5,7 @@ use strict;
 use warnings;
 # Import croak for error reporting
 use Carp 'croak';
+use Scalar::Util 'looks_like_number';
 # Set up export lists
 
 BEGIN {
@@ -29,6 +30,15 @@ BEGIN {
 
 # How many digits exist here 
 sub _digits_size {return length shift}
+
+# Validate that a value is a non-negative integer
+sub _validate_non_negative_integer {
+        my $value = shift;
+        croak "Argument must be a non-negative integer"
+                unless defined $value
+                        && looks_like_number($value)
+                        && $value =~ /^\d+$/;
+}
 
 #Working with just one digits
 #If want a previous value
@@ -97,30 +107,34 @@ sub _previous_even_digits { return _mirror_first_half(shift, 'previous'); }
 #Now, all export functions
 #confirm if the number is palindrome
 sub is_palindrome {
-        my ($x, $validate) = @_;
-        croak "Just work with natural numbers!\n" if $validate && $x !~ /^\d+$/;
+        my ($x) = @_;
+        _validate_non_negative_integer($x);
         return $x eq reverse $x;
 }
 #require the next palindrome 
 sub next_palindrome {
-	my $num = shift;
-	my $size = _digits_size($num);
+        my $num = shift;
+        _validate_non_negative_integer($num);
+        my $size = _digits_size($num);
 	if ($size == 1){return _next_one_digits($num)}
 	elsif ($size % 2 != 0){return _next_odd_digits($num)}
 	else{return _next_even_digits($num)}
 }
 #require the previous palindrome 
 sub previous_palindrome {
-	my $num = shift;
-	my $size = _digits_size($num);
+        my $num = shift;
+        _validate_non_negative_integer($num);
+        my $size = _digits_size($num);
 	if ($size == 1){return _previous_one_digits($num)}
 	elsif ($size % 2 != 0){return _previous_odd_digits($num)}
 	else{return _previous_even_digits($num)}
 }
 #require a crescent sequence
 sub increasing_sequence {
-	my $len = $_[0];
-	my $ini = $_[1] || 0;
+        my $len = $_[0];
+        my $ini = $_[1] || 0;
+        _validate_non_negative_integer($len);
+        _validate_non_negative_integer($ini);
 	my @r;
 	for (1..$len){
 		$r[$_ - 1] = $ini = next_palindrome($ini)
@@ -129,8 +143,10 @@ sub increasing_sequence {
 }
 #require a decrescent sequence
 sub decreasing_sequence {
-	my $len = $_[0];
-	my $ini = $_[1] || 100;
+        my $len = $_[0];
+        my $ini = $_[1] || 100;
+        _validate_non_negative_integer($len);
+        _validate_non_negative_integer($ini);
 	my @r;
 	for (1..$len){
 		$r[$_ -1] = $ini = previous_palindrome($ini)
@@ -141,6 +157,8 @@ sub decreasing_sequence {
 sub palindrome_before {
         my $len = $_[0];
         my $ini = $_[1] || 100;
+        _validate_non_negative_integer($len);
+        _validate_non_negative_integer($ini);
         my $r;
         for (1..$len){
 		$r = $ini = previous_palindrome($ini)
@@ -149,8 +167,10 @@ sub palindrome_before {
 }
 # Return the last number of an increasing sequence
 sub palindrome_after {
-	my $len = $_[0];
-	my $ini = $_[1] || 0;
+        my $len = $_[0];
+        my $ini = $_[1] || 0;
+        _validate_non_negative_integer($len);
+        _validate_non_negative_integer($ini);
 	my $r;
 	for (1..$len){
 		$r = $ini = next_palindrome($ini)

--- a/t/is_palindrome.t
+++ b/t/is_palindrome.t
@@ -33,8 +33,9 @@ ok(!is_palindrome(10000));
 ok(is_palindrome(10001));
 ok(!is_palindrome(100000));
 ok(is_palindrome(100001));
-
-ok(is_palindrome('abcba'));
-ok(!is_palindrome('abc'));
-eval { is_palindrome('foo', 1) };
-ok($@);
+eval { is_palindrome('abc') };
+ok($@ =~ /non-negative integer/);
+eval { is_palindrome(-1) };
+ok($@ =~ /non-negative integer/);
+eval { is_palindrome(1.5) };
+ok($@ =~ /non-negative integer/);

--- a/t/next_palindrome.t
+++ b/t/next_palindrome.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::Simple tests => 24;
+use Test::Simple tests => 27;
 use Math::Palindrome ':all';
 
 
@@ -30,3 +30,9 @@ ok(!next_palindrome(99) != 101);
 ok(next_palindrome(99) == 101);
 ok(!next_palindrome(999) != 1001);
 ok(next_palindrome(999) == 1001);
+eval { next_palindrome('abc') };
+ok($@ =~ /non-negative integer/);
+eval { next_palindrome(-1) };
+ok($@ =~ /non-negative integer/);
+eval { next_palindrome(1.5) };
+ok($@ =~ /non-negative integer/);

--- a/t/others.t
+++ b/t/others.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::Simple tests => 52;
+use Test::Simple tests => 60;
 use Math::Palindrome ':all';
 
 
@@ -12,3 +12,19 @@ my @b = decreasing_sequence(25, 10000);
 ok(is_palindrome($_)) foreach @b;
 ok(palindrome_after(5) == 5);
 ok(palindrome_before(5) == 55);
+eval { increasing_sequence('foo', 0) };
+ok($@ =~ /non-negative integer/);
+eval { increasing_sequence(1, -1) };
+ok($@ =~ /non-negative integer/);
+eval { decreasing_sequence('foo', 100) };
+ok($@ =~ /non-negative integer/);
+eval { decreasing_sequence(1, -1) };
+ok($@ =~ /non-negative integer/);
+eval { palindrome_after('foo') };
+ok($@ =~ /non-negative integer/);
+eval { palindrome_after(1, -1) };
+ok($@ =~ /non-negative integer/);
+eval { palindrome_before('foo') };
+ok($@ =~ /non-negative integer/);
+eval { palindrome_before(1, -1) };
+ok($@ =~ /non-negative integer/);

--- a/t/previous_palindrome.t
+++ b/t/previous_palindrome.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::Simple tests => 34;
+use Test::Simple tests => 37;
 use Math::Palindrome ':all';
 
 
@@ -40,3 +40,9 @@ ok(!previous_palindrome(5) != 4);
 ok(!previous_palindrome(4) != 3);
 ok(!previous_palindrome(3) != 2);
 ok(!previous_palindrome(2) != 1);
+eval { previous_palindrome('abc') };
+ok($@ =~ /non-negative integer/);
+eval { previous_palindrome(-1) };
+ok($@ =~ /non-negative integer/);
+eval { previous_palindrome(1.5) };
+ok($@ =~ /non-negative integer/);


### PR DESCRIPTION
## Summary
- validate all public API arguments with `Scalar::Util::looks_like_number`
- croak when values are not non-negative integers
- add tests for invalid input and error messages

## Testing
- `prove -lr t`


------
https://chatgpt.com/codex/tasks/task_e_68bcb1e82290832a8454df78d4ae47fa